### PR TITLE
Update license markdown and version for v14 compatibility

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -28,19 +28,23 @@ The LGPL 2.1+ license was chosen to:
 ## WHAT THIS MEANS FOR USERS
 
 ### Using the Module
+
 - **Free to use** for any purpose, including commercial
 - **Modifications must be shared** if you distribute the modified module
 - **No restrictions** on creating content that uses the module
 
 ### Contributing to Core
+
 - **Contributions welcome** under LGPL 2.1+
 - **Shared improvements** benefit everyone
 - **Clear licensing** ensures long-term sustainability
 
-## Additional Licensing Provisions:
+## Additional Licensing Provisions
 
 ### Author's Discretionary Licensing
+
 The author (Dalton Sterritt) reserves the right to contribute portions of this codebase to other projects under different licenses on a case-by-case basis. This provision allows for:
+
 - **Selective contributions** to compatible open source projects
 - **Educational use** in tutorials or examples
 - **Community assistance** where different licensing may be beneficial
@@ -50,7 +54,7 @@ Contact the author if you wish to discuss usage under a different license so you
 This discretionary licensing applies only to contributions made by the original author and does not affect the LGPL 2.1+ licensing of the module or the rights of other contributors.
 
 The full text of the LGPL 2.1 license can be found at:
-https://www.gnu.org/licenses/lgpl-2.1.html
+<https://www.gnu.org/licenses/lgpl-2.1.html/>
 
 ## ASSET COMPATIBILITY
 
@@ -65,17 +69,22 @@ that are fully compatible with the LGPL 2.1+ license. This ensures that:
 ## FREQUENTLY ASKED QUESTIONS
 
 ### Can I sell content made with this module as a library?
+
 **Yes.** You can create and sell module packs, campaigns, adventures, and other content that uses the Eventide Teleporter.
 
 ### Do I need to open source my module pack that uses the module?
+
 **No.** Module packs and extensions that use this module as a library can be licensed however you choose.
 
 ### What if I modify the module's code?
+
 **If you distribute** a modified version of the module, those modifications must be shared under LGPL 2.1+.
 **If you only use** the system internally, you don't need to share modifications.
 
 ### Can I include this module in a commercial product?
+
 **Yes.** Both the core moduele and your extensions can be used commercially.
 
 ### What about the included assets?
+
 **All included assets** are compatible with commercial use and LGPL licensing. Attribution requirements are documented above.

--- a/module.json
+++ b/module.json
@@ -1,10 +1,10 @@
 {
   "id": "eventide-teleporter",
   "title": "Eventide Teleporter",
-  "version": "1.0.0",
+  "version": "14.0.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "14"
   },
   "description": "<p>This project is meant to replace the simple teleport module I used for a long time. With foundry's new teleport system. Basically what this does is allows a keybinding (default: m)  to do the following:</p><ol><li><p>Set the currently selected tokens to teleport movement.</p></li><li><p>Start a movement that is unconstrained by walls.</p></li><li><p>Move the selected tokens to where you're hovering when you press m stacked (or, in slow mode, where you click when holding the key).</p></li><li><p>Set the selected tokens back to their original movement mode.</p></li></ol><p>It will have a button on the left-hand side to toggle its modes it so you can control how it works.</p>",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventide-teleporter",
-  "version": "1.0.0",
+  "version": "14.0.0",
   "type": "module",
   "description": "A module for Foundry VTT that allows GMs to teleport tokens around the map.",
   "scripts": {


### PR DESCRIPTION
Revise the license markdown to follow linting rules and update the version number to reflect compatibility with version 14.